### PR TITLE
Enable external browser login for Snowflake

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Sistema automatizado para procesar transcripts de Gong que incluye:
 ```bash
 # Snowflake
 SNOWFLAKE_USER=your_username
-SNOWFLAKE_PASSWORD=your_password
 SNOWFLAKE_ACCOUNT=your_account
 SNOWFLAKE_WAREHOUSE=your_warehouse
 SNOWFLAKE_DATABASE=your_database
 SNOWFLAKE_SCHEMA=your_schema
+SNOWFLAKE_AUTHENTICATOR=externalbrowser
 
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key

--- a/src/fetcher.py
+++ b/src/fetcher.py
@@ -28,11 +28,11 @@ class SnowflakeFetcher:
     def __init__(self):
         self.connection_params = {
             'user': os.getenv('SNOWFLAKE_USER'),
-            'password': os.getenv('SNOWFLAKE_PASSWORD'),
             'account': os.getenv('SNOWFLAKE_ACCOUNT'),
             'warehouse': os.getenv('SNOWFLAKE_WAREHOUSE'),
             'database': os.getenv('SNOWFLAKE_DATABASE'),
-            'schema': os.getenv('SNOWFLAKE_SCHEMA')
+            'schema': os.getenv('SNOWFLAKE_SCHEMA'),
+            'authenticator': os.getenv('SNOWFLAKE_AUTHENTICATOR', 'externalbrowser')
         }
         
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove password-based Snowflake connection
- set authenticator to `externalbrowser`
- document new `SNOWFLAKE_AUTHENTICATOR` variable in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685319edde84832f9ad5b1e3265c5491